### PR TITLE
CO-7541 custom PATH env to call iptables-restore

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,6 +98,7 @@ eos
   execute "reload-ip#{v}tables" do
     command "ip#{v}tables-restore < #{iptable_rules}"
     user "root"
+    environment 'PATH' => '/usr/sbin:/usr/bin:/bin:/sbin'
     action :nothing
   end
 


### PR DESCRIPTION
Additionally to PR #1 

Review:
- [x] @alokdnb 

Issue: Running with cron hourly, chef-client cannot find `iptables-restore` command. chef 14, Centos 7.

Thanks,